### PR TITLE
Adapt Makefile for RPM packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
-CFLAGS=-Wall -Wextra --std=c99 -O2
-CUPSDIR=$(shell cups-config --serverbin)
-CUPSDATADIR=$(shell cups-config --datadir)
+CC ?= gcc
+CFLAGS += -Wall -Wextra --std=c99
+CUPSDIR = $(DESTDIR)$(shell cups-config --serverbin)
+CUPSDATADIR = $(DESTDIR)$(shell cups-config --datadir)
 
 all:	carps-decode rastertocarps ppd/*.ppd
 
 carps-decode:	carps-decode.c carps.h
-	gcc $(CFLAGS) carps-decode.c -o carps-decode
+	$(CC) $(CFLAGS) carps-decode.c -o carps-decode $(LDFLAGS)
 
 rastertocarps:	rastertocarps.c carps.h
-	gcc $(CFLAGS) rastertocarps.c -o rastertocarps -lcupsimage -lcups
+	$(CC) $(CFLAGS) rastertocarps.c -o rastertocarps -lcupsimage -lcups $(LDFLAGS)
 
 ppd/*.ppd: carps.drv
 	ppdc carps.drv
@@ -17,6 +18,9 @@ clean:
 	rm -f carps-decode rastertocarps
 
 install: rastertocarps
-	install -s rastertocarps $(CUPSDIR)/filter/
+	mkdir -p $(CUPSDIR)/filter/
+	mkdir -p $(CUPSDATADIR)/drv/
+	mkdir -p $(CUPSDATADIR)/usb/
+	install -m 755 rastertocarps $(CUPSDIR)/filter/
 	install -m 644 carps.drv $(CUPSDATADIR)/drv/
 	install -m 644 carps.usb-quirks $(CUPSDATADIR)/usb/


### PR DESCRIPTION
When building an RPM via rpmbuild, we need to:
* pass system default compiler flags, example from ROSA 2023.1:
```
$ rpm -E %optflags
-O2 -fomit-frame-pointer -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fPIC -fstack-protector-strong --param=ssp-buffer-size=4 -m64 -mtune=generic
```
* pass system default linker flags
* pass directory where files should be copied to (DESTDIR)
* build an unstripped binary, RPM will strip it by itself and save debuginfo in a special way

All these changes will be usefull for any other packaging format, not only RPM.